### PR TITLE
Skip songs removed from YouTube

### DIFF
--- a/client/src/components/VideoInfoTile.tsx
+++ b/client/src/components/VideoInfoTile.tsx
@@ -8,6 +8,7 @@ interface VideoInfoTileProps {
   videoId: string;
   videoName: string;
   videoDuration: string;
+  videoExists?: boolean;
   thumbnail: string;
   isLoading: boolean;
   showControls?:
@@ -31,6 +32,7 @@ const VideoInfoTile: React.FC<VideoInfoTileProps> = ({
   isLoading,
   addVideo,
   removeVideo,
+  videoExists,
   videoInSelected,
   videoInMedia,
   disabledControls,
@@ -43,7 +45,7 @@ const VideoInfoTile: React.FC<VideoInfoTileProps> = ({
     } else {
       addVideo && addVideo(videoId);
     }
-  }
+  };
 
   return (
     <div className={`relative flex flex-row w-full rounded-xl pr-1 ${videoInSelected ? "bg-gray-300" : ""}`}>
@@ -87,6 +89,7 @@ const VideoInfoTile: React.FC<VideoInfoTileProps> = ({
             <Skeleton width={200} className="self-start" />
           )}
           {!isLoading ? <p className="p1">{videoDuration}</p> : <Skeleton count={1} width={100} />}
+          {videoExists === false && <p className="p3 !text-red-500">Video not available</p>}
         </div>
         {showControls && (
           <div className="flex items-center justify-end">

--- a/client/src/context/types.ts
+++ b/client/src/context/types.ts
@@ -69,4 +69,5 @@ export type Video = {
     }
   },
   duration: number;
+  exists?: boolean;
 }

--- a/client/src/pages/Admin.tsx
+++ b/client/src/pages/Admin.tsx
@@ -53,6 +53,7 @@ const Admin = () => {
                   videoId={video.id.videoId}
                   videoName={video.snippet.title}
                   videoDuration={convertMillisToMinutes(video.duration)}
+                  videoExists={video.exists}
                   thumbnail={video.snippet.thumbnails.high.url}
                   videoInSelected={selectedVideoIds.find((v) => v === video.id.videoId) ? true : false}
                   showControls={{

--- a/server/controllers/media/AddMedia.ts
+++ b/server/controllers/media/AddMedia.ts
@@ -67,11 +67,6 @@ export default async function AddMedia(req: Request, res: Response) {
         })
         .then()
         .catch(() => console.error("Error: Cannot trigger particle"));
-<<<<<<< dev
-
-=======
-        
->>>>>>> main
       videos.shift();
     }
   }

--- a/server/controllers/media/GetJukeboxDataObject.ts
+++ b/server/controllers/media/GetJukeboxDataObject.ts
@@ -1,6 +1,7 @@
 import { errorHandler, getCredentials, getDroppedAsset } from "../../utils/index.js";
 import { Request, Response } from "express";
 import { getAvailableVideos } from "../../utils/youtube/index.js";
+import { checkIsAdmin } from "../../middleware/isAdmin.js";
 
 export default async function GetJukeboxDataObject(req: Request, res: Response) {
   try {
@@ -27,13 +28,16 @@ export default async function GetJukeboxDataObject(req: Request, res: Response) 
         .then()
         .catch(() => console.error("Error sending analytics for views"));
 
-      const videoIds = await getAvailableVideos(jukeboxAsset.dataObject.catalog);
-      jukeboxAsset.dataObject.catalog = jukeboxAsset.dataObject.catalog.map((video) => {
-        return {
-          ...video,
-          exists: videoIds.includes(video.id.videoId),
-        };
-      });
+      const isAdmin = checkIsAdmin(credentials);
+      if (isAdmin) {
+        const videoIds = await getAvailableVideos(jukeboxAsset.dataObject.catalog);
+        jukeboxAsset.dataObject.catalog = jukeboxAsset.dataObject.catalog.map((video) => {
+          return {
+            ...video,
+            exists: videoIds.includes(video.id.videoId),
+          };
+        });
+      }
 
       return res.status(200).json(jukeboxAsset.dataObject);
     }

--- a/server/controllers/media/GetJukeboxDataObject.ts
+++ b/server/controllers/media/GetJukeboxDataObject.ts
@@ -1,6 +1,6 @@
 import { errorHandler, getCredentials, getDroppedAsset } from "../../utils/index.js";
 import { Request, Response } from "express";
-import { checkYouTubeLinksExist, chunkArray, getAvailableVideos } from "../../utils/youtube/index.js";
+import { getAvailableVideos } from "../../utils/youtube/index.js";
 
 export default async function GetJukeboxDataObject(req: Request, res: Response) {
   try {

--- a/server/controllers/media/GetJukeboxDataObject.ts
+++ b/server/controllers/media/GetJukeboxDataObject.ts
@@ -1,5 +1,6 @@
 import { errorHandler, getCredentials, getDroppedAsset } from "../../utils/index.js";
 import { Request, Response } from "express";
+import { checkYouTubeLinksExist, chunkArray, getAvailableVideos } from "../../utils/youtube/index.js";
 
 export default async function GetJukeboxDataObject(req: Request, res: Response) {
   try {
@@ -9,7 +10,6 @@ export default async function GetJukeboxDataObject(req: Request, res: Response) 
       return res.status(404).json({ message: "Asset not found" });
     }
     if (jukeboxAsset) {
-      
       jukeboxAsset
         .updateDataObject(
           {},
@@ -26,6 +26,15 @@ export default async function GetJukeboxDataObject(req: Request, res: Response) 
         )
         .then()
         .catch(() => console.error("Error sending analytics for views"));
+
+      const videoIds = await getAvailableVideos(jukeboxAsset.dataObject.catalog);
+      jukeboxAsset.dataObject.catalog = jukeboxAsset.dataObject.catalog.map((video) => {
+        return {
+          ...video,
+          exists: videoIds.includes(video.id.videoId),
+        };
+      });
+
       return res.status(200).json(jukeboxAsset.dataObject);
     }
   } catch (error: any) {

--- a/server/controllers/media/NextSong.ts
+++ b/server/controllers/media/NextSong.ts
@@ -2,6 +2,19 @@ import redisObj from "../../redis-sse/index.js";
 import { World, getCredentials, getDroppedAsset } from "../../utils/index.js";
 import { Request, Response } from "express";
 import { Video } from "../../types/index.js";
+import { getAvailableVideos } from "../../utils/youtube/index.js";
+
+const findNextAvailableSong = async (queue: string[], catalog: Video[]): Promise<[Video | null, -1]> => {
+  const videoIds = await getAvailableVideos(catalog);
+
+  for (let i = 0; i < queue.length; i++) {
+    const video = catalog.find((v) => v.id.videoId === queue[i]);
+    if (video && videoIds.includes(video.id.videoId)) {
+      return [video, i];
+    }
+  }
+  return [null, -1];
+};
 
 export default async function NextSong(req: Request, res: Response) {
   const credentials = getCredentials(req.body);
@@ -12,14 +25,17 @@ export default async function NextSong(req: Request, res: Response) {
   const { queue } = jukeboxAsset.dataObject;
   const timeFactor = new Date(Math.round(new Date().getTime() / 25000) * 25000);
   const lockId = `${jukeboxAsset.id}_${jukeboxAsset.mediaPlayTime}_${timeFactor}`;
-  const remainingQueue = queue.slice(1);
+  let remainingQueue = [];
   let nowPlaying = "-1" as "-1" | Video;
   const promises = [];
   const analytics = [];
   try {
     if (queue.length > 0) {
-      nowPlaying = jukeboxAsset.dataObject.catalog.find((video: Video) => video.id.videoId === queue[0]) as Video;
+      // nowPlaying = jukeboxAsset.dataObject.catalog.find((video: Video) => video.id.videoId === queue[0]) as Video;
+      const [nextSong, index] = await findNextAvailableSong(queue, jukeboxAsset.dataObject.catalog);
+      nowPlaying = nextSong;
       if (nowPlaying) {
+        remainingQueue = queue.slice(index + 1);
         const videoId = nowPlaying.id.videoId;
         // const videoTitle = nowPlaying.snippet.title;
 
@@ -32,7 +48,7 @@ export default async function NextSong(req: Request, res: Response) {
             duration: 10,
             position: {
               x: jukeboxAsset.position.x,
-              y: jukeboxAsset.position.y - 130
+              y: jukeboxAsset.position.y - 130,
             },
           })
           .then()
@@ -50,6 +66,8 @@ export default async function NextSong(req: Request, res: Response) {
           }),
         );
         analytics.push({ analyticName: "plays", urlSlug: credentials.urlSlug, uniqueKey: credentials.urlSlug });
+      } else {
+        promises.push(jukeboxAsset.updateMediaType({ mediaType: "none" }));
       }
     } else {
       promises.push(jukeboxAsset.updateMediaType({ mediaType: "none" }));

--- a/server/controllers/media/RemoveMedia.ts
+++ b/server/controllers/media/RemoveMedia.ts
@@ -1,4 +1,3 @@
-import { checkIsAdmin } from "../../middleware/isAdmin.js";
 import redisObj from "../../redis-sse/index.js";
 import { Credentials, Video } from "../../types/index.js";
 import { getDroppedAsset } from "../../utils/index.js";

--- a/server/controllers/media/SearchVideos.ts
+++ b/server/controllers/media/SearchVideos.ts
@@ -1,5 +1,5 @@
 import { youtube_v3 } from "@googleapis/youtube";
-import initializeYouTube from "../../external/google.js";
+import yt from "../../external/google.js";
 import { Video } from "../../types";
 import { YTDurationToMilliseconds } from "../../utils/youtube/index.js";
 import { Request, Response } from "express";
@@ -20,7 +20,6 @@ async function getVideoDuration(videos: Video[], yt: youtube_v3.Youtube) {
 }
 
 export default async function SearchVideos(req: Request, res: Response) {
-  const yt = await initializeYouTube();
 
   try {
     const { q, nextPageToken }: { q: string; nextPageToken: string } = req.body;

--- a/server/external/google.ts
+++ b/server/external/google.ts
@@ -10,4 +10,6 @@ async function initializeYouTube() {
   return yt;
 }
 
-export default initializeYouTube;
+const yt = await initializeYouTube();
+
+export default yt;

--- a/server/redis-sse/index.ts
+++ b/server/redis-sse/index.ts
@@ -13,20 +13,12 @@ const shouldSendEvent = (
   );
 };
 
-const connectionOpt = process.env.IS_LOCALHOST
-  ? {
-      password: process.env.REDIS_PASSWORD,
-      socket: {
-        host: process.env.REDIS_URL,
-        port: parseInt(process.env.REDIS_PORT!) || 6379,
-      },
-    }
-  : {
-      url: process.env.REDIS_URL,
-      socket: {
-        tls: process.env.REDIS_URL!.startsWith("rediss"),
-      },
-    };
+const connectionOpt = {
+  url: process.env.REDIS_URL,
+  socket: {
+    tls: process.env.REDIS_URL!.startsWith("rediss"),
+  },
+};
 
 const redisObj = {
   publisher: createClient(connectionOpt),

--- a/server/utils/youtube/index.ts
+++ b/server/utils/youtube/index.ts
@@ -1,4 +1,4 @@
-import yt from "../../external/google";
+import yt from "../../external/google.js";
 
 const YTDurationToMilliseconds = (isoDurationString: string) => {
   const regex =

--- a/server/utils/youtube/index.ts
+++ b/server/utils/youtube/index.ts
@@ -1,4 +1,5 @@
-// @ts-nocheck
+import yt from "../../external/google";
+
 const YTDurationToMilliseconds = (isoDurationString: string) => {
   const regex =
     /^P(?:([.,\d]+)Y)?(?:([.,\d]+)M)?(?:([.,\d]+)W)?(?:([.,\d]+)D)?T(?:([.,\d]+)H)?(?:([.,\d]+)M)?(?:([.,\d]+)S)?$/;
@@ -30,4 +31,44 @@ const YTDurationToMilliseconds = (isoDurationString: string) => {
   }
 };
 
-export { YTDurationToMilliseconds };
+async function getAvailableVideos(catalog) {
+  const allVideoIds = catalog.map((video) => video.id.videoId);
+  const chunkedVideoIds = chunkArray(allVideoIds);
+  const existsOnYTPromises = [];
+  for (const chunk of chunkedVideoIds) {
+    existsOnYTPromises.push(checkYouTubeLinksExist(chunk));
+  }
+
+  const existsOnYT = await Promise.all(existsOnYTPromises);
+  const videoIds = existsOnYT.flat();
+  return videoIds;
+}
+
+async function checkYouTubeLinksExist(videoIds) {
+  try {
+    const response = await yt.videos.list({
+      id: videoIds.join(","),
+      part: "status",
+    });
+
+    const videoData = response.data.items;
+    if (videoData.length > 0) {
+      return videoData.map((video) => video.id); // Returning found video IDs
+    } else {
+      return [];
+    }
+  } catch (error) {
+    console.error("Error fetching video details:", error);
+    return [];
+  }
+}
+
+function chunkArray(arr) {
+  const chunks = [];
+  for (let i = 0; i < arr.length; i += 50) {
+    chunks.push(arr.slice(i, i + 50));
+  }
+  return chunks;
+}
+
+export { YTDurationToMilliseconds, getAvailableVideos };


### PR DESCRIPTION
## Summary
- Some songs get removed from YouTube while they are still in the catalog. This gets the jukebox stuck when it's those songs turn to play. The solution was to check if the videos exist on YouTube before attempting to play them. 
- There was a risk of reaching the YouTube Data API quota when checking if songs exists. To mitigate that
   - Batch `.list` requests to decrease quota. 50 videoIds are chunked together and checked at one time.
   - The check only happens for admins
- Before playing the next song via the `mediaPlayFinished` webhook, we check if the video exists on YT. Since this webhook gets called for every user that's near the jukebox, there was a risk of making too many requests to the YT API. To mitigate that
   - Lock the asset dataObject before calling the YouTube API. This ensures that only the first request makes it through. 
