### PR TITLE
Prevent crashes from API timeouts & fix build issues related to pipeline update

### DIFF
--- a/.github/workflows/aws_auto_release.yml
+++ b/.github/workflows/aws_auto_release.yml
@@ -155,7 +155,7 @@ jobs:
         if: steps.auth_check.outputs.is_authorized == 'true' && steps.check.outputs.should_release == 'true'
         uses: actions/setup-node@v4
         with:
-          node-version: 20.10
+          node-version: ${{ vars.node_version }}
 
       - name: Calculate new version with cumulative bumps
         if: steps.auth_check.outputs.is_authorized == 'true' && steps.check.outputs.should_release == 'true'

--- a/.github/workflows/aws_dev_release.yml
+++ b/.github/workflows/aws_dev_release.yml
@@ -45,7 +45,7 @@ jobs:
                   
       - uses: actions/setup-node@v4
         with:
-          node-version: 20.10
+          node-version: ${{ vars.node_version }}
           cache: 'npm'
       - run: npm i
       - name: Build
@@ -67,7 +67,7 @@ jobs:
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v4
         with:
-          role-to-assume: arn:aws:iam::368076259134:role/github-actions-role
+          role-to-assume: ${{ fromJSON(secrets.AWS_ROLE_ARN).dev }}
           aws-region: us-east-1
 
       - name: Login to Amazon ECR
@@ -115,7 +115,7 @@ jobs:
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v4
         with:
-          role-to-assume: arn:aws:iam::368076259134:role/github-actions-role
+          role-to-assume: ${{ fromJSON(secrets.AWS_ROLE_ARN).dev }}
           aws-region: us-east-1
 
       - name: deploy

--- a/.github/workflows/aws_dev_release.yml
+++ b/.github/workflows/aws_dev_release.yml
@@ -64,10 +64,18 @@ jobs:
         with:
           platforms: arm64,amd64
 
+      - name: Get role ARN
+        id: get_role
+        env:
+          ARN_JSON: ${{ secrets.AWS_ROLE_ARN }}
+        run: |
+          arn=$(echo "$ARN_JSON" | jq -r '.dev')
+          echo "::add-mask::$arn"
+          echo "arn=$arn" >> $GITHUB_OUTPUT
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v4
         with:
-          role-to-assume: ${{ fromJSON(secrets.AWS_ROLE_ARN).dev }}
+          role-to-assume: ${{ steps.get_role.outputs.arn }}
           aws-region: us-east-1
 
       - name: Login to Amazon ECR
@@ -112,10 +120,18 @@ jobs:
       matrix:
         service: ${{ fromJson(needs.Build.outputs.service) }}
     steps:
+      - name: Get role ARN
+        id: get_role
+        env:
+          ARN_JSON: ${{ secrets.AWS_ROLE_ARN }}
+        run: |
+          arn=$(echo "$ARN_JSON" | jq -r '.dev')
+          echo "::add-mask::$arn"
+          echo "arn=$arn" >> $GITHUB_OUTPUT
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v4
         with:
-          role-to-assume: ${{ fromJSON(secrets.AWS_ROLE_ARN).dev }}
+          role-to-assume: ${{ steps.get_role.outputs.arn }}
           aws-region: us-east-1
 
       - name: deploy

--- a/.github/workflows/aws_prod_release.yml
+++ b/.github/workflows/aws_prod_release.yml
@@ -46,7 +46,7 @@ jobs:
 
       - uses: actions/setup-node@v4
         with:
-          node-version: 20.10
+          node-version: ${{ vars.node_version }}
           cache: 'npm'
       - run: git config --global user.email devops@topia.io
       - run: git config --global user.name Devops
@@ -71,7 +71,7 @@ jobs:
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v4
         with:
-          role-to-assume: arn:aws:iam::368076259134:role/github-actions-role
+          role-to-assume: ${{ fromJSON(secrets.AWS_ROLE_ARN).prod }}
           aws-region: us-east-1
                     
       - name: Login to Amazon ECR
@@ -118,7 +118,7 @@ jobs:
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v4
         with:
-          role-to-assume: arn:aws:iam::471112828260:role/github-actions-role
+          role-to-assume: ${{ fromJSON(secrets.AWS_ROLE_ARN).prod }}
           aws-region: us-east-1
 
       - name: deploy

--- a/.github/workflows/aws_prod_release.yml
+++ b/.github/workflows/aws_prod_release.yml
@@ -62,18 +62,27 @@ jobs:
             echo "::error::Build failed"
             exit 1
           fi
-                  
+
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3.0.0
         with:
           platforms: arm64,amd64
-                    
+
+      - name: Get role ARN
+        id: get_role
+        env:
+          ARN_JSON: ${{ secrets.AWS_ROLE_ARN }}
+        run: |
+          arn=$(echo "$ARN_JSON" | jq -r '.dev')
+          echo "::add-mask::$arn"
+          echo "arn=$arn" >> $GITHUB_OUTPUT
+
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v4
         with:
-          role-to-assume: ${{ fromJSON(secrets.AWS_ROLE_ARN).prod }}
+          role-to-assume: ${{ steps.get_role.outputs.arn }}
           aws-region: us-east-1
-                    
+
       - name: Login to Amazon ECR
         id: login-ecr
         uses: aws-actions/amazon-ecr-login@v2
@@ -115,13 +124,21 @@ jobs:
       matrix:
         service: ${{ fromJson(needs.Build.outputs.service) }}
     steps:
+      - name: Get role ARN
+        id: get_role
+        env:
+          ARN_JSON: ${{ secrets.AWS_ROLE_ARN }}
+        run: |
+          arn=$(echo "$ARN_JSON" | jq -r '.prod')
+          echo "::add-mask::$arn"
+          echo "arn=$arn" >> $GITHUB_OUTPUT
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v4
         with:
-          role-to-assume: ${{ fromJSON(secrets.AWS_ROLE_ARN).prod }}
+          role-to-assume: ${{ steps.get_role.outputs.arn }}
           aws-region: us-east-1
 
       - name: deploy
         run: |
-          aws ecs update-service --cluster ${{ env.ECS_Cluster }} --service topia-${{ env.ENV }}-${{ matrix.service }}0 --force-new-deployment  
-                
+          aws ecs update-service --cluster ${{ env.ECS_Cluster }} --service topia-${{ env.ENV }}-${{ matrix.service }}0 --force-new-deployment
+

--- a/server/index.ts
+++ b/server/index.ts
@@ -77,6 +77,22 @@ if (process.env.NODE_ENV !== "development") {
   });
 }
 
+
+// Prevent crashes from unhandled promise rejections (e.g., API timeouts after response sent)
+process.on("unhandledRejection", (reason, promise) => {
+  console.error("Unhandled Rejection:", reason);
+});
+
+process.on("uncaughtException", (error) => {
+  // ERR_HTTP_HEADERS_SENT is non-fatal — response was already sent, just log it
+  if ((error as any).code === "ERR_HTTP_HEADERS_SENT") {
+    console.error("Caught ERR_HTTP_HEADERS_SENT (response already sent):", error.message);
+    return;
+  }
+  console.error("Uncaught Exception:", error);
+  process.exit(1);
+});
+
 app.listen(PORT, () => {
   console.log(`Server is running on port: ${PORT}`);
 });

--- a/server/utils/errorHandler.ts
+++ b/server/utils/errorHandler.ts
@@ -30,11 +30,11 @@ export const errorHandler = ({
       }),
     );
 
-    if (res) return res.status(error.status || 500).send({ error, message, success: false });
+    if (res && !res.headersSent) return res.status(error.status || 500).send({ error, message, success: false });
     return { error };
   } catch (e) {
     console.error("❌ Error printing the logs", e);
-    if (res) return res.status(500).send({ error: e, message, success: false });
-    return { e };
+    if (res && !res.headersSent) return res.status(500).send({ error: e, message, success: false });
+    return { error: e };
   }
 };


### PR DESCRIPTION
Summary:
- Add res.headersSent guard in errorHandler to prevent double-send crashes when Topia public API returns 502 timeout
- Add unhandledRejection and uncaughtException process handlers as safety net
- Fixes intermittent app crashes during API timeouts

Test plan:
- [ ] Verify app continues to handle normal errors correctly
- [ ] Verify app does not crash when an SDK call times out mid-request
- [ ] Verify error is logged but response completes gracefully when headers already sent

Generated with Claude Code (https://claude.com/claude-code)